### PR TITLE
fix(copier-template): disable auto-merging (for now at least)

### DIFF
--- a/copier-template.json
+++ b/copier-template.json
@@ -11,5 +11,15 @@
     "**/test/**",
     "**/tests/**",
     "**/__fixtures__/**"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "copier"
+      ],
+      "extends": [
+        ":automergeDisabled"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Closes dafyddj/base-bootstrap#168